### PR TITLE
Apply small changes to allow this library to cope with floating point record durations

### DIFF
--- a/Project/Lib/EDF/Header.cs
+++ b/Project/Lib/EDF/Header.cs
@@ -181,7 +181,7 @@ namespace SharpLib.EuropeanDataFormat
         public FixedLengthInt SizeInBytes { get; private set; } = new FixedLengthInt(HeaderItems.SizeInBytes);
         public FixedLengthString Reserved { get; private set; } = new FixedLengthString(HeaderItems.Reserved);
         public FixedLengthInt RecordCount { get; private set; } = new FixedLengthInt(HeaderItems.NumberOfDataRecords);
-        public FixedLengthInt RecordDurationInSeconds { get; private set; } = new FixedLengthInt(HeaderItems.RecordDurationInSeconds);
+        public FixedLengthDouble RecordDurationInSeconds { get; private set; } = new FixedLengthDouble(HeaderItems.RecordDurationInSeconds);
         public FixedLengthInt SignalCount { get; private set; } = new FixedLengthInt(HeaderItems.SignalCount);
 
         public class Signal

--- a/Project/Lib/EDF/Reader.cs
+++ b/Project/Lib/EDF/Reader.cs
@@ -205,7 +205,7 @@ namespace SharpLib.EuropeanDataFormat
         private Double ReadDouble(Field itemInfo)
         {
             String value = ReadAscii(itemInfo).Trim();
-            if (Double.TryParse(value, out var result) {
+            if (Double.TryParse(value, out var result)) {
                 return result;
             } else {
                 return -1;

--- a/Project/Lib/EDF/Reader.cs
+++ b/Project/Lib/EDF/Reader.cs
@@ -205,9 +205,10 @@ namespace SharpLib.EuropeanDataFormat
         private Double ReadDouble(Field itemInfo)
         {
             String value = ReadAscii(itemInfo).Trim();
-            if (Double.TryParse(value, out var result)) {
-                return result;
-            } else {
+            try {
+                return Double.Parse(value, CultureInfo.InvariantCulture);
+            } catch (FormatExcepection ex) {
+                Console.WriteLine("Error, could not convert string to integer: " + ex.Message);
                 return -1;
             }
         }

--- a/Project/Lib/EDF/Reader.cs
+++ b/Project/Lib/EDF/Reader.cs
@@ -27,7 +27,7 @@ namespace SharpLib.EuropeanDataFormat
             h.SizeInBytes.Value = ReadInt16(HeaderItems.SizeInBytes);
             h.Reserved.Value = ReadAscii(HeaderItems.Reserved);
             h.RecordCount.Value = ReadInt16(HeaderItems.NumberOfDataRecords);
-            h.RecordDurationInSeconds.Value = ReadInt16(HeaderItems.RecordDurationInSeconds);
+            h.RecordDurationInSeconds.Value = ReadDouble(HeaderItems.RecordDurationInSeconds);
             h.SignalCount.Value = ReadInt16(HeaderItems.SignalCount);
 
             // Variable size header
@@ -200,6 +200,16 @@ namespace SharpLib.EuropeanDataFormat
             try { intResult = Convert.ToInt16(strInt); }
             catch (Exception ex) { Console.WriteLine("Error, could not convert string to integer. " + ex.Message); }
             return intResult;
+        }
+        
+        private Double ReadDouble(Field itemInfo)
+        {
+            String value = ReadAscii(itemInfo).Trim();
+            if (Double.TryParse(value, out var result) {
+                return result;
+            } else {
+                return -1;
+            }
         }
 
         private string ReadAscii(Field itemInfo)

--- a/Project/Lib/EDF/Reader.cs
+++ b/Project/Lib/EDF/Reader.cs
@@ -207,7 +207,7 @@ namespace SharpLib.EuropeanDataFormat
             String value = ReadAscii(itemInfo).Trim();
             try {
                 return Double.Parse(value, CultureInfo.InvariantCulture);
-            } catch (FormatExcepection ex) {
+            } catch (FormatException ex) {
                 Console.WriteLine("Error, could not convert string to integer: " + ex.Message);
                 return -1;
             }


### PR DESCRIPTION
In the header of edf files it is possible that the RecordDurationInSeconds is given as a float instead of an int (with all decimal digits being zero).

This pull request has been created to ensure that these files can still be read successfully.