### PR TITLE
Fix error with more that 100000 annotations.

### DIFF
--- a/Project/Lib/EDF/AnnotationSignal.cs
+++ b/Project/Lib/EDF/AnnotationSignal.cs
@@ -124,16 +124,30 @@ namespace SharpLib.EuropeanDataFormat
 
         public static byte[] GetBytesForTALIndex(int index)
         {
+            var strIndex = index.ToString();
+            var leftSide =  (strIndex.Length>1)? strIndex.Substring(0, strIndex.Length - 1): "0";
+            var rightSide = strIndex.Substring(strIndex.Length - 1);
+
+            List<byte> result = new List<byte>();
+            result.AddRange(Encoding.ASCII.GetBytes("+"));
+            result.AddRange(Encoding.ASCII.GetBytes(leftSide));
+            result.Add(TAL.byte_46);
+            result.AddRange(Encoding.ASCII.GetBytes(rightSide));
+            result.Add(TAL.byte_20);
+            result.Add(TAL.byte_20);
+            result.Add(TAL.byte_0);
+            /*
             List<byte> result = new List<byte>();
             float indexF = (float)index / 10;
             var leftSide = Math.Truncate(indexF);
-            var rightSide = (int)((decimal)indexF % 1 * 10);
+            var rightSide = (int)(((decimal)indexF % 1) * 10);
             result.AddRange(Encoding.ASCII.GetBytes($"+{leftSide}"));
             result.Add(TAL.byte_46);
             result.AddRange(Encoding.ASCII.GetBytes($"{rightSide}"));
             result.Add(TAL.byte_20);
             result.Add(TAL.byte_20);
             result.Add(TAL.byte_0);
+            */
             return result.ToArray();
         }
     }


### PR DESCRIPTION
The new version manages as a string the index transformations to obtain the right and left parts of the byte representation of the TAL index.
This avoids precision errors in type transformations and operations that were used in the previous version when the index is a large number. 