### PR TITLE
Fix error when record count exceeds 32767

### DIFF
--- a/Project/Lib/EDF/Reader.cs
+++ b/Project/Lib/EDF/Reader.cs
@@ -26,7 +26,7 @@ namespace SharpLib.EuropeanDataFormat
             h.RecordingStartTime.Value = ReadAscii(HeaderItems.RecordingStartTime);
             h.SizeInBytes.Value = ReadInt16(HeaderItems.SizeInBytes);
             h.Reserved.Value = ReadAscii(HeaderItems.Reserved);
-            h.RecordCount.Value = ReadInt16(HeaderItems.NumberOfDataRecords);
+            h.RecordCount.Value = ReadInt32(HeaderItems.NumberOfDataRecords);
             h.RecordDurationInSeconds.Value = ReadDouble(HeaderItems.RecordDurationInSeconds);
             h.SignalCount.Value = ReadInt16(HeaderItems.SignalCount);
 
@@ -201,7 +201,16 @@ namespace SharpLib.EuropeanDataFormat
             catch (Exception ex) { Console.WriteLine("Error, could not convert string to integer. " + ex.Message); }
             return intResult;
         }
-        
+
+        private Int32 ReadInt32(Field itemInfo)
+        {
+            string strInt = ReadAscii(itemInfo).Trim();
+            Int32 intResult = -1;
+            try { intResult = Convert.ToInt32(strInt); }
+            catch (Exception ex) { Console.WriteLine("Error, could not convert string to integer. " + ex.Message); }
+            return intResult;
+        }
+
         private Double ReadDouble(Field itemInfo)
         {
             String value = ReadAscii(itemInfo).Trim();


### PR DESCRIPTION
Hi!
When I was trying to read a EDF file, I got a wrong data record count: -1.

Properties of my file:
- Sample rate: 500
- Data record duration: 0.1 second (That is, there are 50 samples in each data record)
- File duration: about 3 hours

As a result, the actual data record count is:
3 x 60 x 60 x 500 / 50 = 108000

which is large than Int16.MaxValue.

With this patch, I can parse my file successfully.

BTW, this is not a very big file. Suppose there are 32 signals in this file. Then the file size is about:

3 * 60 * 60 * 500 * 32 * 2 bytes ≈ 330 MiB
