### PR TITLE
Fix NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![NuGet Badge](https://buildstats.info/nuget/SharpLibEuropeanDataFormat)](https://www.nuget.org/packages/SharpLibEuropeanDataFormat/)
+[![NuGet Badge](https://img.shields.io/nuget/v/SharpLibEuropeanDataFormat)](https://www.nuget.org/packages/SharpLibEuropeanDataFormat/)
 [![Build](https://github.com/Slion/SharpLibEuropeanDataFormat/actions/workflows/build.yml/badge.svg)](https://github.com/Slion/SharpLibEuropeanDataFormat/actions/workflows/build.yml) 
 [![Publish](https://github.com/Slion/SharpLibEuropeanDataFormat/actions/workflows/publish.yml/badge.svg)](https://github.com/Slion/SharpLibEuropeanDataFormat/actions/workflows/publish.yml)
 [![License](https://img.shields.io/github/license/Slion/SharpLibEuropeanDataFormat)](LICENSE.md)


### PR DESCRIPTION
The website https://buildstats.info/ has become inaccessible, and its source code repository https://github.com/dustinmoris/CI-BuildStats was archived on 2024.08.31. Therefore, the NuGet badge should be updated: https://shields.io/badges/nu-get-version.

